### PR TITLE
Update peewee_migrate and pass schema as parameter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ multidict==2.1.4
 nltk==3.2.2
 pbr==3.1.1
 peewee==2.10.1
-peewee-migrate==0.12.3
+peewee-migrate==0.13.1
 psycopg2==2.6.2
 py==1.4.32
 pytest==3.0.6

--- a/tasks/migrate-production.py
+++ b/tasks/migrate-production.py
@@ -1,14 +1,9 @@
 from peewee_migrate import Router
 from playhouse.db_url import connect
 
-# FIXME: Dirty way to pass the schema for migration history so that peewee_migrate will work properly.
-# More information: https://github.com/klen/peewee_migrate/issues/51
-from peewee_migrate import MigrateHistory
-MigrateHistory._meta.schema = 'system'
-
 database = connect('postgresql://postgres@karelia-17.it.helsinki.fi:5432/learning-from-our-past')
 
-router = Router(database)
+router = Router(database, schema='system')
 
 # Run all unapplied migrations
 router.run()

--- a/tasks/migrate.py
+++ b/tasks/migrate.py
@@ -1,18 +1,14 @@
-# FIXME: Dirty way to pass the schema for migration history so that peewee_migrate will work properly.
-# More information: https://github.com/klen/peewee_migrate/issues/51
-from peewee_migrate import MigrateHistory
 from peewee_migrate import Router
 from config import CONFIG
 
 from db_management.models.db_connection import db_connection
 
-MigrateHistory._meta.schema = 'system'
 
 db_connection.init_database(db_name=CONFIG['db_name'], db_user=CONFIG['db_admin'])
 db_connection.connect()
 database = db_connection.get_database()
 
-router = Router(database)
+router = Router(database, schema='system')
 
 # Run all unapplied migrations
 router.run()

--- a/tasks/new-migration.py
+++ b/tasks/new-migration.py
@@ -5,7 +5,7 @@ from config import CONFIG
 db_connection.init_database(db_name=CONFIG['db_name'], db_user=CONFIG['db_admin'])
 db_connection.connect()
 database = db_connection.get_database()
-router = Router(database)
+router = Router(database, schema='system')
 
 # Create migration
 router.create('migration_name')

--- a/tests/utils/dbUtils.py
+++ b/tests/utils/dbUtils.py
@@ -10,11 +10,6 @@ import logging
 from peewee_migrate import LOGGER
 LOGGER.setLevel(logging.WARN)
 
-# FIXME: Dirty way to pass the schema for migration history so that peewee_migrate will work properly.
-# More information: https://github.com/klen/peewee_migrate/issues/51
-from peewee_migrate import MigrateHistory
-MigrateHistory._meta.schema = 'system'
-
 """
 Provides basic services to manage database during tests such as functions to create, drop and truncate
 contents of the testdbs. Loads configurations from test-config.json file on start up.
@@ -95,7 +90,7 @@ class DBUtils:
         self.peewee_database.connect()
 
         # Run all unapplied migrations
-        router = Router(self.peewee_database)
+        router = Router(self.peewee_database, schema='system')
         router.run()
 
     def truncate_db(self):


### PR DESCRIPTION
Library was updated and now schema can be passed as Router param instead
of having to dig into MigrateHistory  model.