### PR TITLE
Fix testing environment setup

### DIFF
--- a/kairatools/Makefile
+++ b/kairatools/Makefile
@@ -1,5 +1,5 @@
 test:
-	cd ..; python -m pytest kairatools
+	export APP_SETTINGS=testing; cd ..; python -m pytest kairatools
 
 new-migration:
 	cd ..; python -m kairatools.tasks.new_migration


### PR DESCRIPTION
Tests did not work for kairatools since APP_SETTINGS were not
set correctly. Tests worked on if .env file was present, but used development
config. Now environment is explicitly set when make test is run.