### PR TITLE
Move local database population commands to the makefile

### DIFF
--- a/database/Makefile
+++ b/database/Makefile
@@ -11,7 +11,11 @@ migrate-production:
 	cd ..; python -m database.tasks.migrate-production
 
 populate-all-local:
-	cd ..; sh database/tasks/populate_everything.sh
+	cd ..;\
+	python -m database.main database/material/siirtokarjalaiset_I.json;\
+	python -m database.main database/material/siirtokarjalaiset_II.json;\
+	python -m database.main database/material/siirtokarjalaiset_III.json;\
+	python -m database.main database/material/siirtokarjalaiset_IV.json;
 
 update-production:
 	cd ..; python database/main.py $(file) -a karelia-17.it.helsinki.fi -p 5432 -d learning-from-our-past

--- a/database/tasks/populate_everything.sh
+++ b/database/tasks/populate_everything.sh
@@ -1,8 +1,0 @@
-python main.py material/siirtokarjalaiset_I.json 
-python main.py material/siirtokarjalaiset_II.json 
-python main.py material/siirtokarjalaiset_III.json 
-python main.py material/siirtokarjalaiset_IV.json 
-
-python -m script_tools.mark_ambiguous_region_places_in_db
-
-echo 'All done!'


### PR DESCRIPTION
Remove the .sh files that the broken database population commands
were in previously and add fixed versions of the commands to the
Makefile.