### PR TITLE
Fix postgres commands in setup task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ create-venv:
 	virtualenv -p python3 database-venv
 
 setup:
-	psql template1 -c 'create extension hstore'; # install hstore extension to default database template
+	psql -U postgres template1 -c 'create extension hstore'; # install hstore extension to default database template
 	pip install -r requirements.txt;
-	createdb learning-from-our-past
+	createdb -U postgres learning-from-our-past
 	psql -U postgres -d learning-from-our-past -a -f database/sql/initial_db.sql
 	python -m database.tasks.migrate
 	python -m kairatools.tasks.migrate


### PR DESCRIPTION
Some of the commands lacked -U option requiring to run the
task as a postgres user or other super user. Set the user
explicitly in all commands.